### PR TITLE
fix: add package json to root

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "tf4micro-motion-kit",
+  "version": "1.0.0",
+  "main": "web/index.js",
+  "license": "MIT",
+  "exports": {
+    "./": "./web/"
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "web",
+  "name": "tf4micro-motion-kit-dev",
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
This PR adds a package.json to fix install issues when using the git repo as a yarn / npm package source.

The package.json uses the `exports` field which was introduced in 2020 to expose the /web folder.

Should fix: https://github.com/googlecreativelab/astrowand/issues/1